### PR TITLE
V2 FormInterface: Don’t invoke attributes in initialize

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nueca_rails_interfaces (1.0.0)
+    nueca_rails_interfaces (1.1.1)
       rails (>= 7, < 9)
       to_bool (~> 2.1)
 
@@ -84,7 +84,6 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     builder (3.3.0)
-    byebug (12.0.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -261,7 +260,6 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  byebug
   nueca_rails_interfaces!
   rake
   rspec (~> 3.0)

--- a/lib/nueca_rails_interfaces/v2/form_interface.rb
+++ b/lib/nueca_rails_interfaces/v2/form_interface.rb
@@ -3,7 +3,6 @@
 module NuecaRailsInterfaces
   module V2
     # V2 Form Interface is the same as V1 Form Interface,
-    # except forces an exception on the attributes method when intializing a form.
     module FormInterface
       class << self
         # Allows the form mixin to include ActiveModel::Model powers.

--- a/lib/nueca_rails_interfaces/v2/form_interface.rb
+++ b/lib/nueca_rails_interfaces/v2/form_interface.rb
@@ -20,10 +20,8 @@ module NuecaRailsInterfaces
       end
 
       # Initializes the form with the options passed in.
-      # It also calls the attributes method to ensure it is implemented.
       def initialize(options = {})
         super(**options)
-        attributes
       end
 
       # Final attributes to be returned by the form after validation.

--- a/spec/nueca_rails_interfaces/v2/form_interface_spec.rb
+++ b/spec/nueca_rails_interfaces/v2/form_interface_spec.rb
@@ -24,18 +24,6 @@ RSpec.describe NuecaRailsInterfaces::V2::FormInterface do
           expect(form.new.attributes).to eq(name: 'John Doe')
         end
       end
-
-      context 'when the form does not implement attributes' do
-        let(:form) do
-          Class.new do
-            include NuecaRailsInterfaces::V2::FormInterface
-          end
-        end
-
-        it 'raises a NotImplementedError on initialization' do
-          expect { form.new }.to raise_error(NotImplementedError, 'Requires implementation of attributes.')
-        end
-      end
     end
   end
 
@@ -54,18 +42,6 @@ RSpec.describe NuecaRailsInterfaces::V2::FormInterface do
 
         it 'validates properly' do
           expect(form.check).to be_a(form)
-        end
-      end
-
-      context 'when the form does not implement attributes' do
-        let(:form) do
-          Class.new do
-            include NuecaRailsInterfaces::V2::FormInterface
-          end
-        end
-
-        it 'raises a NotImplementedError on validation' do
-          expect { form.check }.to raise_error(NotImplementedError, 'Requires implementation of attributes.')
         end
       end
     end


### PR DESCRIPTION
### Summary

This changes `NuecaRailsInterfaces::V2::FormInterface` so that:
* initialize no longer calls `attributes`.
* The abstract `attributes` method still exists and must be implemented by consumers.

### Why (Problem)
Calling `attributes` inside `initialize` is problematic because:
* It forces `attribute` derivation before validation. If `attributes` depends on validated inputs (e.g., `customer_id` must be present), it may compute with missing/invalid data.
* It can trigger unnecessary work (DB lookups, mapping, coercions) even when the form will ultimately be invalid.
* It makes it harder to write forms whose `attributes` is intentionally lazy or guarded by validity.
* It surprises users: you say "you must provide `customer_id`", yet you eagerly compute `attributes` on construction with a possibly missing `customer_id`.

